### PR TITLE
feature(cli): graceful shutdown with grace period

### DIFF
--- a/.rr.yaml
+++ b/.rr.yaml
@@ -217,5 +217,5 @@ endure:
   grace_period: 30s
   # default false, print graph in the graphviz format to the stdout (paste here to visualize https://dreampuf.github.io)
   print_graph: false
-  # default debug, possible values: debug, info, warning, error, panic, fatal
-  log_level: debug
+  # default error, possible values: debug, info, warning, error, panic, fatal
+  log_level: error

--- a/.rr.yaml
+++ b/.rr.yaml
@@ -21,8 +21,9 @@ server:
 # optional for development
 logs:
   # default
-  mode: debug
-  encoding: json
+  mode: development
+  level: debug
+  encoding: console
   output: stderr
   err_output: stderr
   channels:
@@ -34,7 +35,12 @@ logs:
     server:
       mode: production
       level: info
-      encoding: json
+      encoding: console
+      output: stderr
+    rpc:
+      mode: production
+      level: debug
+      encoding: console
       output: stderr
 
 # Workflow and activity mesh service
@@ -99,7 +105,7 @@ http:
     supervisor:
       # watch_tick defines how often to check the state of the workers (seconds)
       watch_tick: 1s
-      # ttl defines maximum time worker is allowed to live (seconds)
+      # ttl defines maximum time worker is allowed to live (seconds) (soft)
       ttl: 0
       # idle_ttl defines maximum duration worker can spend in idle mode after first use. Disabled when 0 (seconds)
       idle_ttl: 10s
@@ -205,3 +211,13 @@ reload:
       # directories to sync. If recursive is set to true,
       # recursive sync will be applied only to the directories in `dirs` section
       dirs: [ "." ]
+
+endure:
+  # default 10s to finish
+  grace_period: 10s
+  # default false
+  print_graph: false
+  # default false
+  retry_on_fail: false
+  # default debug
+  log_level: debug

--- a/.rr.yaml
+++ b/.rr.yaml
@@ -213,11 +213,9 @@ reload:
       dirs: [ "." ]
 
 endure:
-  # default 10s to finish
-  grace_period: 10s
-  # default false
+  # default 30s to finish, possible values 10s,100m,5h
+  grace_period: 30s
+  # default false, print graph in the graphviz format to the stdout (paste here to visualize https://dreampuf.github.io)
   print_graph: false
-  # default false
-  retry_on_fail: false
-  # default debug
+  # default debug, possible values: debug, info, warning, error, panic, fatal
   log_level: debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@ CHANGELOG
 
 vnext (.2021)
 -------------------
-
-- 🐛 Update ldflags to properly inject RR version
-- ⬆️ Update README, links to the go.pkg from v1 to v2
-- 📦 Bump golang version in the Dockerfile to 1.16
+- 🐛 Fix: incorrect PHP command validation
+- 🐛 Fix: ldflags properly inject RR version
+- ⬆️ Update: README, links to the go.pkg from v1 to v2
+- 📦 Bump golang version in the Dockerfile and in the `go.mod` to 1.16
 
 v2.0.0 (02.03.2021)
 -------------------

--- a/cli/plugins.go
+++ b/cli/plugins.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"github.com/spiral/roadrunner/v2/plugins/gzip"
+	"github.com/spiral/roadrunner/v2/plugins/headers"
+	httpPlugin "github.com/spiral/roadrunner/v2/plugins/http"
+	"github.com/spiral/roadrunner/v2/plugins/informer"
+	"github.com/spiral/roadrunner/v2/plugins/logger"
+	"github.com/spiral/roadrunner/v2/plugins/metrics"
+	"github.com/spiral/roadrunner/v2/plugins/reload"
+	"github.com/spiral/roadrunner/v2/plugins/resetter"
+	rpcPlugin "github.com/spiral/roadrunner/v2/plugins/rpc"
+	"github.com/spiral/roadrunner/v2/plugins/server"
+	"github.com/spiral/roadrunner/v2/plugins/static"
+	"github.com/spiral/roadrunner/v2/plugins/status"
+	"github.com/temporalio/roadrunner-temporal/activity"
+	temporalClient "github.com/temporalio/roadrunner-temporal/client"
+	"github.com/temporalio/roadrunner-temporal/workflow"
+)
+
+// Add plugins should be registered here
+var plugins []interface{} = []interface{}{
+	// logger plugin
+	&logger.ZapLogger{},
+	// metrics plugin
+	&metrics.Plugin{},
+	// http server plugin
+	&httpPlugin.Plugin{},
+	// reload plugin
+	&reload.Plugin{},
+	// informer plugin (./rr workers, ./rr workers -i)
+	&informer.Plugin{},
+	// resetter plugin (./rr reset)
+	&resetter.Plugin{},
+	// rpc plugin (workers, reset)
+	&rpcPlugin.Plugin{},
+	// server plugin (NewWorker, NewWorkerPool)
+	&server.Plugin{},
+
+	// static
+	&static.Plugin{},
+	// headers
+	&headers.Plugin{},
+	// checker
+	&status.Plugin{},
+	// gzip
+	&gzip.Plugin{},
+
+	// temporal plugins
+	&activity.Plugin{},
+	&workflow.Plugin{},
+	&temporalClient.Plugin{},
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -218,7 +218,7 @@ func initEndureConfig() *EndureConfig {
 	}
 
 	if e.LogLevel == "" {
-		e.LogLevel = "debug"
+		e.LogLevel = "error"
 	}
 
 	if e.GracePeriod == 0 {

--- a/cli/root.go
+++ b/cli/root.go
@@ -56,6 +56,7 @@ var (
 	// Container is the pointer to the Endure container
 	Container   *endure.Endure
 	RetryOnFail bool
+	GracePeriod time.Duration = time.Second * 30
 	cfg         *config.Viper
 	override    []string
 	root        = &cobra.Command{
@@ -225,6 +226,7 @@ func initEndureConfig() *EndureConfig {
 		e.GracePeriod = time.Second * 30
 	}
 
+	GracePeriod = e.GracePeriod
 	RetryOnFail = e.RetryOnFail
 
 	return e

--- a/cli/root.go
+++ b/cli/root.go
@@ -42,7 +42,7 @@ const EndureKey string = "endure"
 type EndureConfig struct {
 	GracePeriod time.Duration `mapstructure:"grace_period"`
 	PrintGraph  bool          `mapstructure:"print_graph"`
-	RetryOnFail bool          `mapstructure:"retry_on_fail"`
+	RetryOnFail bool          `mapstructure:"retry_on_fail"` //TODO check for races, disabled at the moment
 	LogLevel    string        `mapstructure:"log_level"`
 }
 
@@ -54,10 +54,11 @@ var (
 	// Debug mode
 	Debug bool
 	// Container is the pointer to the Endure container
-	Container *endure.Endure
-	cfg       *config.Viper
-	override  []string
-	root      = &cobra.Command{
+	Container   *endure.Endure
+	RetryOnFail bool
+	cfg         *config.Viper
+	override    []string
+	root        = &cobra.Command{
 		Use:           "rr",
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -223,6 +224,8 @@ func initEndureConfig() *EndureConfig {
 	if e.GracePeriod == 0 {
 		e.GracePeriod = time.Second * 30
 	}
+
+	RetryOnFail = e.RetryOnFail
 
 	return e
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -40,10 +40,10 @@ const EndureKey string = "endure"
 
 // EndureConfig represents container configuration
 type EndureConfig struct {
-	gracePeriod time.Duration
-	printGraph  bool
-	retryOnFail bool
-	logLevel    string
+	GracePeriod time.Duration `mapstructure:"grace_period"`
+	PrintGraph  bool          `mapstructure:"print_graph"`
+	RetryOnFail bool          `mapstructure:"retry_on_fail"`
+	LogLevel    string        `mapstructure:"log_level"`
 }
 
 var (
@@ -114,9 +114,9 @@ func init() {
 			panic("endure config should not be nil")
 		}
 
-		lvl := endure.DebugLevel
+		var lvl endure.Level
 
-		switch endureCfg.logLevel {
+		switch endureCfg.LogLevel {
 		case "debug":
 			lvl = endure.DebugLevel
 		case "info":
@@ -130,15 +130,14 @@ func init() {
 		case "fatal":
 			lvl = endure.FatalLevel
 		default:
-			fmt.Println(fmt.Sprintf("unknown log level, provided: %s, availabe: debug, info, warning, error, panic, fatal", endureCfg.logLevel))
-			return
+			panic(fmt.Sprintf("unknown log level, provided: %s, availabe: debug, info, warning, error, panic, fatal\n", endureCfg.LogLevel))
 		}
 
 		var err error
-		if endureCfg.printGraph {
-			Container, err = endure.NewContainer(nil, endure.SetLogLevel(lvl), endure.RetryOnFail(endureCfg.retryOnFail), endure.SetStopTimeOut(endureCfg.gracePeriod), endure.Visualize(endure.StdOut, ""))
+		if endureCfg.PrintGraph {
+			Container, err = endure.NewContainer(nil, endure.SetLogLevel(lvl), endure.RetryOnFail(endureCfg.RetryOnFail), endure.SetStopTimeOut(endureCfg.GracePeriod), endure.Visualize(endure.StdOut, ""))
 		} else {
-			Container, err = endure.NewContainer(nil, endure.SetLogLevel(lvl), endure.RetryOnFail(endureCfg.retryOnFail), endure.SetStopTimeOut(endureCfg.gracePeriod))
+			Container, err = endure.NewContainer(nil, endure.SetLogLevel(lvl), endure.RetryOnFail(endureCfg.RetryOnFail), endure.SetStopTimeOut(endureCfg.GracePeriod))
 		}
 
 		if err != nil {
@@ -204,10 +203,10 @@ func initEndureConfig() *EndureConfig {
 	// init default config
 	if !c.Has(EndureKey) {
 		return &EndureConfig{
-			gracePeriod: time.Second * 10,
-			printGraph:  false,
-			retryOnFail: false,
-			logLevel:    "debug",
+			GracePeriod: time.Second * 30,
+			PrintGraph:  false,
+			RetryOnFail: false,
+			LogLevel:    "debug",
 		}
 	}
 
@@ -217,12 +216,12 @@ func initEndureConfig() *EndureConfig {
 		panic(err)
 	}
 
-	if e.logLevel == "" {
-		e.logLevel = "debug"
+	if e.LogLevel == "" {
+		e.LogLevel = "debug"
 	}
 
-	if e.gracePeriod == 0 {
-		e.gracePeriod = time.Second * 10
+	if e.GracePeriod == 0 {
+		e.GracePeriod = time.Second * 30
 	}
 
 	return e

--- a/cli/root.go
+++ b/cli/root.go
@@ -12,21 +12,8 @@ import (
 	"github.com/spiral/errors"
 
 	goridgeRpc "github.com/spiral/goridge/v3/pkg/rpc"
-	"github.com/spiral/roadrunner/v2/plugins/gzip"
-	"github.com/spiral/roadrunner/v2/plugins/headers"
-	httpPlugin "github.com/spiral/roadrunner/v2/plugins/http"
-	"github.com/spiral/roadrunner/v2/plugins/informer"
-	"github.com/spiral/roadrunner/v2/plugins/logger"
-	"github.com/spiral/roadrunner/v2/plugins/metrics"
-	"github.com/spiral/roadrunner/v2/plugins/reload"
-	"github.com/spiral/roadrunner/v2/plugins/resetter"
+
 	rpcPlugin "github.com/spiral/roadrunner/v2/plugins/rpc"
-	"github.com/spiral/roadrunner/v2/plugins/server"
-	"github.com/spiral/roadrunner/v2/plugins/static"
-	"github.com/spiral/roadrunner/v2/plugins/status"
-	"github.com/temporalio/roadrunner-temporal/activity"
-	temporalClient "github.com/temporalio/roadrunner-temporal/client"
-	"github.com/temporalio/roadrunner-temporal/workflow"
 
 	"github.com/spiral/roadrunner/v2/plugins/config"
 
@@ -146,38 +133,17 @@ func init() {
 			log.Fatal(err)
 		}
 
-		err = Container.RegisterAll(
-			// logger plugin
-			&logger.ZapLogger{},
-			// metrics plugin
-			&metrics.Plugin{},
-			// http server plugin
-			&httpPlugin.Plugin{},
-			// reload plugin
-			&reload.Plugin{},
-			// informer plugin (./rr workers, ./rr workers -i)
-			&informer.Plugin{},
-			// resetter plugin (./rr reset)
-			&resetter.Plugin{},
-			// rpc plugin (workers, reset)
-			&rpcPlugin.Plugin{},
-			// server plugin (NewWorker, NewWorkerPool)
-			&server.Plugin{},
-
-			// static
-			&static.Plugin{},
-			// headers
-			&headers.Plugin{},
-			// checker
-			&status.Plugin{},
-			// gzip
-			&gzip.Plugin{},
-
-			// temporal plugins
-			&activity.Plugin{},
-			&workflow.Plugin{},
-			&temporalClient.Plugin{},
-
+		// register plugin from the plugins.go
+		for i := 0; i < len(plugins); i++ {
+			err = Container.Register(
+				// register plugin
+				plugins[i],
+			)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+		err = Container.Register(
 			// register config
 			cfg,
 		)

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -53,6 +52,8 @@ func handler(_ *cobra.Command, _ []string) error {
 		// after first hit we are waiting for the second
 		// second catch - exit from the process
 		<-shutdownHandler
+		println("\n")
+		println("exit forced")
 		os.Exit(1)
 	}()
 
@@ -71,10 +72,11 @@ func handler(_ *cobra.Command, _ []string) error {
 			}
 
 		case <-stop:
+			log.Printf("stop signal received, grace timeout is: %d seconds", uint64(GracePeriod.Seconds()))
 			// stop the container after first signal
 			err = Container.Stop()
 			if err != nil {
-				fmt.Printf("error occured during the stopping container: %v \n", err)
+				log.Printf("error occured during the stopping container: %v \n", err)
 			}
 			return nil
 		}

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -38,25 +39,43 @@ func handler(_ *cobra.Command, _ []string) error {
 
 	// https://golang.org/pkg/os/signal/#Notify
 	// should be of buffer size at least 1
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+	shutdownHandler := make(chan os.Signal, 2)
+	signal.Notify(shutdownHandler, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+
+	stop := make(chan struct{}, 1)
+
+	go func() {
+		// first catch - stop the container
+		<-shutdownHandler
+
+		// after first hit we are waiting for the second
+		go func() {
+			// second catch - exit from the process
+			<-shutdownHandler
+			os.Exit(1)
+		}()
+
+		// stop the container after first signal
+		err = Container.Stop()
+		if err != nil {
+			fmt.Println(fmt.Sprintf("error occured during the stopping container: %v", err))
+		}
+		// if container stopped, normally exit
+		stop <- struct{}{}
+	}()
 
 	for {
 		select {
 		case e := <-errCh:
 			err = multierr.Append(err, e.Error)
-			log.Printf("error occurred: %v, service: %s", e.Error.Error(), e.VertexID)
+			log.Printf("error occurred: %v, plugin: %s", e.Error.Error(), e.VertexID)
 			er := Container.Stop()
 			if er != nil {
 				err = multierr.Append(err, er)
 				return errors.E(op, err)
 			}
 			return errors.E(op, err)
-		case <-c:
-			err = Container.Stop()
-			if err != nil {
-				return errors.E(op, err)
-			}
+		case <-stop:
 			return nil
 		}
 	}

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -58,7 +58,7 @@ func handler(_ *cobra.Command, _ []string) error {
 		// stop the container after first signal
 		err = Container.Stop()
 		if err != nil {
-			fmt.Println(fmt.Sprintf("error occured during the stopping container: %v", err))
+			fmt.Printf("error occured during the stopping container: %v \n", err)
 		}
 		// if container stopped, normally exit
 		stop <- struct{}{}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,3 @@ require (
 	github.com/vbauerster/mpb/v5 v5.4.0
 	go.uber.org/multierr v1.6.0
 )
-
-replace (
-	github.com/spiral/roadrunner/v2 v2.0.0 => ../roadrunner
-)

--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,7 @@ require (
 	github.com/vbauerster/mpb/v5 v5.4.0
 	go.uber.org/multierr v1.6.0
 )
+
+replace (
+	github.com/spiral/roadrunner/v2 v2.0.0 => ../roadrunner
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spiral/roadrunner-binary/v2
 
-go 1.15
+go 1.16
 
 require (
 	github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129
@@ -14,4 +14,8 @@ require (
 	github.com/temporalio/roadrunner-temporal v1.0.0
 	github.com/vbauerster/mpb/v5 v5.4.0
 	go.uber.org/multierr v1.6.0
+)
+
+replace (
+	github.com/spiral/roadrunner/v2 v2.0.0 => ../roadrunner
 )

--- a/main.go
+++ b/main.go
@@ -1,15 +1,9 @@
 package main
 
 import (
-
-
-	// plugins
 	"github.com/spiral/roadrunner-binary/v2/cli"
-
 )
 
 func main() {
-
-
 	cli.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,9 @@ import (
 	"github.com/spiral/roadrunner-binary/v2/cli"
 )
 
+// PLUGINS LOCATED IN THE cli/plugins.go
+// All new plugins should be added here
+
 func main() {
 	cli.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,71 +1,15 @@
 package main
 
 import (
-	"log"
 
-	endure "github.com/spiral/endure/pkg/container"
-	"github.com/spiral/roadrunner/v2/plugins/gzip"
-	"github.com/spiral/roadrunner/v2/plugins/headers"
-	"github.com/spiral/roadrunner/v2/plugins/static"
-	"github.com/spiral/roadrunner/v2/plugins/status"
 
 	// plugins
 	"github.com/spiral/roadrunner-binary/v2/cli"
-	httpPlugin "github.com/spiral/roadrunner/v2/plugins/http"
-	"github.com/spiral/roadrunner/v2/plugins/informer"
-	"github.com/spiral/roadrunner/v2/plugins/logger"
-	"github.com/spiral/roadrunner/v2/plugins/metrics"
-	"github.com/spiral/roadrunner/v2/plugins/reload"
-	"github.com/spiral/roadrunner/v2/plugins/resetter"
-	"github.com/spiral/roadrunner/v2/plugins/rpc"
-	"github.com/spiral/roadrunner/v2/plugins/server"
-	"github.com/temporalio/roadrunner-temporal/activity"
-	temporalClient "github.com/temporalio/roadrunner-temporal/client"
-	"github.com/temporalio/roadrunner-temporal/workflow"
+
 )
 
 func main() {
-	var err error
-	cli.Container, err = endure.NewContainer(nil, endure.SetLogLevel(endure.ErrorLevel), endure.RetryOnFail(false))
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	err = cli.Container.RegisterAll(
-		// logger plugin
-		&logger.ZapLogger{},
-		// metrics plugin
-		&metrics.Plugin{},
-		// http server plugin
-		&httpPlugin.Plugin{},
-		// reload plugin
-		&reload.Plugin{},
-		// informer plugin (./rr workers, ./rr workers -i)
-		&informer.Plugin{},
-		// resetter plugin (./rr reset)
-		&resetter.Plugin{},
-		// rpc plugin (workers, reset)
-		&rpc.Plugin{},
-		// server plugin (NewWorker, NewWorkerPool)
-		&server.Plugin{},
-
-		// static
-		&static.Plugin{},
-		// headers
-		&headers.Plugin{},
-		// checker
-		&status.Plugin{},
-		// gzip
-		&gzip.Plugin{},
-
-		// temporal plugins
-		&activity.Plugin{},
-		&workflow.Plugin{},
-		&temporalClient.Plugin{},
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	cli.Execute()
 }


### PR DESCRIPTION
# Reason for This PR

closes https://github.com/spiral/roadrunner/issues/555
ref https://github.com/temporalio/roadrunner-temporal/issues/34

## Description of Changes

- Add configurable grace period. The default is 30s.
- Add endure configuration section:
```yaml
endure:
  # default 30s to finish, possible values 10s,100m,5h
  grace_period: 30s
  # default false, print graph in the graphviz format to the stdout (paste here to visualize https://dreampuf.github.io)
  print_graph: false
  # default debug
  log_level: debug
```
- First signal (SIGINT, SIGTERM) activates grace period to finish plugins. The second signal (SIGINT, SIGTERM) forces the application to exit with a non-zero error code.
- Plugins declaration moved to the `cli/plugins.go`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
