### PR TITLE
fix(endure): use error log level by default

### DIFF
--- a/internal/container/config.go
+++ b/internal/container/config.go
@@ -27,7 +27,7 @@ func NewConfig(cfgPlugin *config.Viper) (*Config, error) {
 			GracePeriod: defaultGracePeriod,
 			PrintGraph:  false,
 			RetryOnFail: false,
-			LogLevel:    endure.DebugLevel,
+			LogLevel:    endure.ErrorLevel,
 		}, nil
 	}
 

--- a/internal/container/config_test.go
+++ b/internal/container/config_test.go
@@ -42,7 +42,7 @@ func TestNewConfig_WithoutEndureKey(t *testing.T) {
 	assert.Equal(t, time.Second*30, c.GracePeriod)
 	assert.False(t, c.PrintGraph)
 	assert.False(t, c.RetryOnFail)
-	assert.Equal(t, endure.DebugLevel, c.LogLevel)
+	assert.Equal(t, endure.ErrorLevel, c.LogLevel)
 }
 
 func TestNewConfig_LoggingLevels(t *testing.T) {


### PR DESCRIPTION
# Reason for This PR

- Use error log level for the endure by default

## Description of Changes

- If there is no endure config key, use error log level instead of debug

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~
~- [ ] All added/changed functionality is tested.~
