### PR TITLE
fix(env): Do not use any name for the env by default

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -84,7 +84,7 @@ func NewCommand(cmdName string) *cobra.Command { //nolint:funlen
 
 	f.StringVarP(&cfgFile, "config", "c", ".rr.yaml", "config file")
 	f.StringVarP(&workDir, "WorkDir", "w", "", "working directory") // TODO change to `workDir`?
-	f.StringVarP(&dotenv, "dotenv", "", ".env", fmt.Sprintf("dotenv file [$%s]", envDotenv))
+	f.StringVarP(&dotenv, "dotenv", "", "", fmt.Sprintf("dotenv file [$%s]", envDotenv))
 	f.BoolVarP(&debug, "debug", "d", false, "debug mode")
 	f.StringArrayVarP(&override, "override", "o", nil, "override config value (dot.notation=value)")
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -46,7 +46,7 @@ func TestCommandFlags(t *testing.T) {
 	}{
 		{giveName: "config", wantShorthand: "c", wantDefault: ".rr.yaml"},
 		{giveName: "WorkDir", wantShorthand: "w", wantDefault: ""},
-		{giveName: "dotenv", wantShorthand: "", wantDefault: ".env"},
+		{giveName: "dotenv", wantShorthand: "", wantDefault: ""},
 		{giveName: "debug", wantShorthand: "d", wantDefault: "false"},
 		{giveName: "override", wantShorthand: "o", wantDefault: "[]"},
 	}


### PR DESCRIPTION
# Reason for This PR

closes #41 

## Description of Changes

- Update tests, want by default empty string in the root_test.go
- Update `--dotenv` default path (empty string)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
~- [ ] Any required documentation changes (code and docs) are included in this PR.~
~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
