### PR TITLE
fix(container): do not call the container's Stop method after the container is stopped by an error

### DIFF
--- a/internal/cli/serve/command.go
+++ b/internal/cli/serve/command.go
@@ -11,11 +11,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spiral/errors"
 	"github.com/spiral/roadrunner/v2/plugins/config"
-	"go.uber.org/multierr"
 )
 
 // NewCommand creates `serve` command.
-func NewCommand(cfgPlugin *config.Viper) *cobra.Command { //nolint:funlen,gocognit
+func NewCommand(cfgPlugin *config.Viper) *cobra.Command { //nolint:funlen
 	return &cobra.Command{
 		Use:   "serve",
 		Short: "Start RoadRunner server",
@@ -81,11 +80,8 @@ func NewCommand(cfgPlugin *config.Viper) *cobra.Command { //nolint:funlen,gocogn
 				case e := <-errCh:
 					fmt.Printf("error occurred: %v, plugin: %s\n", e.Error, e.VertexID)
 
+					// return error, container already stopped internally
 					if !containerCfg.RetryOnFail {
-						if er := endureContainer.Stop(); er != nil {
-							return errors.E(op, multierr.Append(e.Error, er))
-						}
-
 						return errors.E(op, e.Error)
 					}
 


### PR DESCRIPTION
# Reason for This PR

- `fsm_recognizer: can't transition from state: Stopped by event Stop` error in the logs after container stopped by error.

## Description of Changes

- Remove the redundant container.Stop() call after error

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
