### PR TITLE
update(ci): Version value extracting improved

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,12 @@ jobs:
       - name: Download dependencies
         run: go mod download # `-x` means "verbose" mode
 
+      - uses: gacts/github-slug@v1
+        id: slug
+
       - name: Generate builder values
         id: values
         run: |
-          echo "::set-output name=version::`echo ${GITHUB_REF##*/} | sed -e 's/^[vV ]*//'`"
           echo "::set-output name=timestamp::`date +%FT%T%z`"
           echo "::set-output name=binary-name::rr`[ ${{ matrix.os }} = 'windows' ] && echo '.exe'`"
 
@@ -63,7 +65,7 @@ jobs:
           CGO_ENABLED: 0
           LDFLAGS: >-
             -s
-            -X github.com/spiral/roadrunner-binary/v2/internal/meta.version=${{ steps.values.outputs.version }}
+            -X github.com/spiral/roadrunner-binary/v2/internal/meta.version=${{ steps.slug.outputs.version }}
             -X github.com/spiral/roadrunner-binary/v2/internal/meta.buildTime=${{ steps.values.outputs.timestamp }}
         run: |
           go build -trimpath -ldflags "$LDFLAGS" -o "./${{ steps.values.outputs.binary-name }}" ./cmd/rr
@@ -72,7 +74,7 @@ jobs:
       - name: Generate distributive directory name
         id: dist-dir
         run: >
-          echo "::set-output name=name::roadrunner-${{ steps.values.outputs.version }}-$(
+          echo "::set-output name=name::roadrunner-${{ steps.slug.outputs.version }}-$(
             [ ${{ matrix.os }} != '' ] && echo '${{ matrix.os }}' || echo 'unknown'
           )$(
             [ ${{ matrix.compiler }} = 'musl-gcc' ] && echo '-musl'
@@ -126,6 +128,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - uses: gacts/github-slug@v1
+        id: slug
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1 # Action page: <https://github.com/docker/setup-qemu-action>
 
@@ -147,20 +152,20 @@ jobs:
 
       - name: Generate builder values
         id: values
-        run: |
-          echo "::set-output name=version::`echo ${GITHUB_REF##*/} | sed -e 's/^[vV ]*//'`"
-          echo "::set-output name=timestamp::`date +%FT%T%z`"
+        run: echo "::set-output name=timestamp::`date +%FT%T%z`"
 
       - name: Build image
-        run: |
-          docker buildx build \
-            --platform "linux/amd64,linux/arm64" \
-            --tag "spiralscout/roadrunner:latest" \
-            --tag "spiralscout/roadrunner:${{ steps.values.outputs.version }}" \
-            --tag "ghcr.io/spiral/roadrunner:latest" \
-            --tag "ghcr.io/spiral/roadrunner:${{ steps.values.outputs.version }}" \
-            --build-arg "APP_VERSION=${{ steps.values.outputs.version }}" \
-            --build-arg "BUILD_TIME=${{ steps.values.outputs.timestamp }}" \
-            --file ./Dockerfile \
-            --push \
-            .
+        uses: docker/build-push-action@v2 # Action page: <https://github.com/docker/build-push-action>
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=${{ steps.slug.outputs.version }}
+            BUILD_TIME=${{ steps.values.outputs.timestamp }}
+          tags: |
+            spiralscout/roadrunner:latest
+            spiralscout/roadrunner:${{ steps.slug.outputs.version }}
+            ghcr.io/spiral/roadrunner:latest
+            ghcr.io/spiral/roadrunner:${{ steps.slug.outputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,11 +107,11 @@ jobs:
       - name: Install Go dependencies
         run: go mod download && go mod verify
 
-      - name: Generate version value
-        id: values # for PR this value will be `merge@__hash__`, SO: <https://stackoverflow.com/a/59780579/2252921>
-        run: |
-          echo "::set-output name=version::`echo ${GITHUB_REF##*/}`@`echo ${GITHUB_SHA} | cut -c1-8`"
-          echo "::set-output name=timestamp::`date +%FT%T%z`"
+      - uses: gacts/github-slug@v1
+        id: slug
+
+      - id: values
+        run: echo "::set-output name=timestamp::`date +%FT%T%z`"
 
       - name: Compile binary file
         env:
@@ -119,7 +119,7 @@ jobs:
           GOARCH: amd64
           CGO_ENABLED: 0
           LDFLAGS: -s
-            -X github.com/spiral/roadrunner-binary/v2/internal/meta.version=${{ steps.values.outputs.version }}
+            -X github.com/spiral/roadrunner-binary/v2/internal/meta.version=${{ steps.slug.outputs.version }}@${{ steps.slug.outputs.commit-hash-short }}
             -X github.com/spiral/roadrunner-binary/v2/internal/meta.buildTime=${{ steps.values.outputs.timestamp }}
         run: go build -trimpath -ldflags "$LDFLAGS" -o ./rr ./cmd/rr
 


### PR DESCRIPTION
# Reason for This PR

Version extracting during the CI process can be improved using [gacts/github-slug](https://github.com/gacts/github-slug) GitHub action (I'm the author of this action)

## Description of Changes

- Docker image building now uses the [docker/build-push-action](https://github.com/docker/build-push-action) action
- Version extracting now uses [gacts/github-slug](https://github.com/gacts/github-slug) action :smiley: 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
