### PR TITLE
fix(config): wrong port values

### DIFF
--- a/.rr.yaml
+++ b/.rr.yaml
@@ -614,13 +614,13 @@ http:
       # Alternate port for the http challenge. Challenge traffic should be redirected to this port if overridden.
       #
       # Optional. Default: 80
-      alt_http_port: 80,
+      alt_http_port: 80
 
 
       # Alternate port for the tls-alpn-01 challenge. Challenge traffic should be redirected to this port if overridden.
       #
       # Optional. Default: 443.
-      alt_tlsalpn_port: 443,
+      alt_tlsalpn_port: 443
 
       # Challenge types
       #


### PR DESCRIPTION
# Reason for This PR

When executing `rr` with provided file, we got following error:
```
* cannot parse 'ssl.acme.alt_http_port' as int: strconv.ParseInt: parsing "80,": invalid syntax
* cannot parse 'ssl.acme.alt_tlsalpn_port' as int: strconv.ParseInt: parsing "443,": invalid syntax
```

## Description of Changes

Removal of the misleading `,`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

## Misc.

Thank you for your work 😄 